### PR TITLE
Add get_pid method requirements

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -43,3 +43,11 @@ fallback_manager.register("git.status", offline_repo_status)
 Calling `fallback_manager.run("git.status")` tries the main handler first and
 runs the fallback on error. Remove the handler with
 `fallback_manager.unregister("git.status")`.
+
+## Resource monitoring
+
+Long-running modules that maintain background threads or spawn subprocesses
+should expose a ``get_pid()`` method returning the operating system process
+ID. :class:`modules.resource_limiter.ResourceLimiter` relies on this method to
+track CPU and memory usage. Modules running entirely in the main process can
+simply ``return os.getpid()``.

--- a/modules/resource_limiter.py
+++ b/modules/resource_limiter.py
@@ -1,9 +1,17 @@
-"""Resource usage monitoring for active Jarvis modules."""
+"""Resource usage monitoring for active Jarvis modules.
+
+Modules that run for extended periods should implement a ``get_pid()`` method
+returning their process ID. The limiter calls this method on every active
+module and uses :mod:`psutil` to collect CPU and memory metrics for that PID.
+If usage exceeds the quota provided by ``get_resource_quota()``, a
+``ResourceLimitWarning`` event is emitted and the module is flagged.
+"""
 
 REQUIRES = ["psutil"]
 
 import threading
 import time
+import os
 
 import psutil
 import logging
@@ -93,3 +101,7 @@ class ResourceLimiter:
         self.running = False
         if self._thread:
             self._thread.join(timeout=0)
+
+    def get_pid(self) -> int:
+        """Return the current process ID for monitoring."""
+        return os.getpid()

--- a/modules/self_diagnostics.py
+++ b/modules/self_diagnostics.py
@@ -3,6 +3,7 @@ import time
 import asyncio
 from typing import Any
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,10 @@ class SelfDiagnostics:
         self.running = False
         if self._thread:
             self._thread.join(timeout=0)
+
+    def get_pid(self) -> int:
+        """Return the current process ID for resource monitoring."""
+        return os.getpid()
 
     def _run(self) -> None:
         while self.running:

--- a/modules/voice_interface/interface.py
+++ b/modules/voice_interface/interface.py
@@ -131,3 +131,7 @@ class VoiceInterface:
                 pass
         print("🔇 Голос отключён.")
         return "🔇 Голос отключён."
+
+    def get_pid(self) -> int:
+        """Return the PID of the running process for resource monitoring."""
+        return os.getpid()

--- a/plugins/system_health_monitor.py
+++ b/plugins/system_health_monitor.py
@@ -2,6 +2,7 @@ import psutil
 import time
 import threading
 from datetime import datetime
+import os
 
 
 class SystemHealthMonitor:
@@ -20,6 +21,10 @@ class SystemHealthMonitor:
         self.running = False
         if self.thread.is_alive():
             self.thread.join()
+
+    def get_pid(self) -> int:
+        """Return the current process ID for monitoring."""
+        return os.getpid()
 
     def _monitor(self) -> None:
         while self.running:

--- a/tests/test_resource_limiter.py
+++ b/tests/test_resource_limiter.py
@@ -47,3 +47,23 @@ def test_resource_limiter_flags_module():
 
     assert default_flag_manager.is_flagged("dummy")
     assert any(e[0] == "ModuleAnomalyFlagged" for e in events)
+
+
+def test_resource_limiter_skips_module_without_pid():
+    events = []
+    register_event_emitter(lambda n, d: events.append((n, d)))
+
+    class NoPid:
+        name = "nopid"
+
+        def get_resource_quota(self) -> dict:
+            return {"memory": 0, "cpu": 0}
+
+    register_module_supplier(lambda: [NoPid()])
+
+    limiter = ResourceLimiter(interval=0.1)
+    limiter.start()
+    time.sleep(0.2)
+    limiter.stop()
+
+    assert events == []


### PR DESCRIPTION
# - [x] ~~~~## Summary
- clarify in modules doc that long running modules must implement `get_pid()`
- expand ResourceLimiter docstring
- implement `get_pid()` in several long running modules
- update `ResourceLimiter` tests with a case for modules missing `get_pid`

## Testing
- `pytest -q` *(fails: FastAPI depends on pydantic not compatible with Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_e_685dfae62734832db4137c4a810bb5b0