### PR TITLE
Add optional SecureEventQueue

### DIFF
--- a/jarvis/app.py
+++ b/jarvis/app.py
@@ -546,7 +546,12 @@ class Jarvis:
         logger.debug(
             f"Публикация события: {event_name} с {args}, {kwargs}, priority={priority}"
         )
-        await self.event_queue.emit(event_name, *args, priority=priority, **kwargs)
+        token = None
+        if hasattr(self.event_queue, "get_token"):
+            token = self.event_queue.get_token(event_name)
+        await self.event_queue.emit(
+            event_name, *args, priority=priority, token=token, **kwargs
+        )
 
     def subscribe_event(self, event_name: str, listener: Callable):
         self.event_queue.subscribe(event_name, listener)

--- a/jarvis/core/agent_loop.py
+++ b/jarvis/core/agent_loop.py
@@ -57,7 +57,10 @@ class AgentLoop:
             context: Dict[str, Any] = {"user_id": user_id, **kwargs}
             context.update(parsed)
             result = await self.jarvis.brain.think(text, context)
-            await self.queue.emit("action_result", result)
+            token = None
+            if hasattr(self.queue, "get_token"):
+                token = self.queue.get_token("action_result")
+            await self.queue.emit("action_result", result, token=token)
         except Exception as e:  # pragma: no cover - logging only
             logger.exception("Failed to process input: %s", e)
 

--- a/jarvis/core/main.py
+++ b/jarvis/core/main.py
@@ -27,6 +27,7 @@ from jarvis.core.agent_loop import AgentLoop
 from jarvis.core.module_manager import ModuleManager, ModuleConfig
 from jarvis.core.sensor_manager import ScheduledTask, SensorManager
 from jarvis.event_queue import EventQueue
+from jarvis.secure_event_queue import SecureEventQueue
 from jarvis.goal_manager import GoalManager
 from jarvis.memory.manager import MemoryManager
 from jarvis.nlp.processor import NLUProcessor
@@ -41,6 +42,13 @@ from core.module_registry import register_module_supplier
 import core.system_initializer  # noqa: F401 - triggers diagnostics startup
 
 logger = get_logger().getChild("Core")
+
+BUILTIN_EVENTS = [
+    "voice_command",
+    "scheduled_tick",
+    "user_input",
+    "action_result",
+]
 
 
 class UserEvent(BaseModel):
@@ -72,6 +80,7 @@ class Settings(BaseSettings):
     intent_model_path: str = "models/intent"
     clarify_threshold: float = 0.5
     autoload_modules: Dict[str, int] = {}
+    use_secure_channels: bool = False
 
     class Config:
         env_file = ".env"
@@ -132,12 +141,23 @@ class Jarvis:
         self.nlu = NLUProcessor(model_path=self.settings.intent_model_path)
         self.brain = Brain(self)
         self.goals = GoalManager(self)
-        self.event_queue = EventQueue()
+        if self.settings.use_secure_channels:
+            self.event_queue = SecureEventQueue()
+            for name in BUILTIN_EVENTS:
+                self.event_queue.register_token(name, name)
+        else:
+            self.event_queue = EventQueue()
         self.sensor_manager = SensorManager(self, self.event_queue)
         self.module_manager = ModuleManager(self)
         register_module_supplier(lambda: list(self.module_manager.modules.values()))
         register_event_emitter(
-            lambda name, data: asyncio.create_task(self.event_queue.emit(name, data))
+            lambda name, data: asyncio.create_task(
+                self.event_queue.emit(
+                    name,
+                    data,
+                    token=getattr(self.event_queue, "get_token", lambda _: None)(name),
+                )
+            )
         )
         self.agent_loop = None
         self._pending_question: Optional[str] = None

--- a/jarvis/core/sensor_manager.py
+++ b/jarvis/core/sensor_manager.py
@@ -57,7 +57,10 @@ class SensorManager:
             try:
                 text = await voice.listen()
                 if text:
-                    await self.event_queue.emit("voice_command", text)
+                    token = None
+                    if hasattr(self.event_queue, "get_token"):
+                        token = self.event_queue.get_token("voice_command")
+                    await self.event_queue.emit("voice_command", text, token=token)
             except asyncio.CancelledError:
                 break
             await asyncio.sleep(0.1)
@@ -69,7 +72,12 @@ class SensorManager:
                 now = time.monotonic()
                 for task in list(self.scheduled_tasks):
                     if now >= task.next_run:
-                        await self.event_queue.emit("scheduled_tick", task=task)
+                        token = None
+                        if hasattr(self.event_queue, "get_token"):
+                            token = self.event_queue.get_token("scheduled_tick")
+                        await self.event_queue.emit(
+                            "scheduled_tick", task=task, token=token
+                        )
                         task.next_run = now + task.interval
                 await asyncio.sleep(1)
             except asyncio.CancelledError:

--- a/jarvis/secure_event_queue.py
+++ b/jarvis/secure_event_queue.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, Optional
+
+from jarvis.event_queue import EventQueue
+
+
+class SecureEventQueue(EventQueue):
+    """EventQueue that validates tokens for registered events."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tokens: Dict[str, str] = {}
+
+    def register_token(self, event_name: str, token: str) -> None:
+        """Register *token* for *event_name*."""
+        self._tokens[event_name] = token
+
+    def get_token(self, event_name: str) -> Optional[str]:
+        return self._tokens.get(event_name)
+
+    async def emit(
+        self,
+        event_name: str,
+        *args: Any,
+        priority: int = 0,
+        token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        expected = self._tokens.get(event_name)
+        if expected is not None and token != expected:
+            return
+        await super().emit(event_name, *args, priority=priority, **kwargs)

--- a/tests/test_secure_event_queue.py
+++ b/tests/test_secure_event_queue.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+
+from jarvis.secure_event_queue import SecureEventQueue
+
+
+@pytest.mark.asyncio
+async def test_secure_event_queue_token_validation():
+    eq = SecureEventQueue()
+    eq.register_token("secret", "tok")
+    received = []
+    eq.subscribe("secret", lambda x: received.append(x))
+    await eq.start()
+    await eq.emit("secret", 1, token="tok")
+    await eq.emit("secret", 2, token="bad")
+    await asyncio.sleep(0.05)
+    await eq.stop()
+    assert received == [1]
+
+
+@pytest.mark.asyncio
+async def test_secure_event_queue_fallback_to_eventqueue():
+    eq = SecureEventQueue()
+    await eq.start()
+    received = []
+    eq.subscribe("no_token", lambda x: received.append(x))
+    await eq.emit("no_token", 3)
+    await asyncio.sleep(0.05)
+    await eq.stop()
+    assert received == [3]

--- a/tests/test_sensor_manager.py
+++ b/tests/test_sensor_manager.py
@@ -31,7 +31,7 @@ async def test_microphone_loop_emits(monkeypatch):
 
     await sm._microphone_loop()
 
-    assert ("voice_command", ("hello",), {}) in events
+    assert ("voice_command", ("hello",), {"token": None}) in events
 
 
 @pytest.mark.asyncio
@@ -61,3 +61,4 @@ async def test_scheduled_loop_emits_tick(monkeypatch):
 
     assert events and events[0][0] == "scheduled_tick"
     assert events[0][1]["task"] is task
+    assert events[0][1]["token"] is None


### PR DESCRIPTION
## Summary
- implement `SecureEventQueue` with token validation
- add `use_secure_channels` setting and default token registration for built‑in events
- emit tokens when built-in components publish events
- handle tokens in `publish_event`
- add tests for the secure queue and update sensor manager tests

## Testing
- `pytest tests/test_secure_event_queue.py -q`
- `pytest tests/test_sensor_manager.py -q`
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*

------
https://chatgpt.com/codex/tasks/task_e_685dfafb01a0832d86f1e9eeb811077b