### PR TITLE
Add SecureEventQueue with token validation

### DIFF
--- a/jarvis/core/module_manager.py
+++ b/jarvis/core/module_manager.py
@@ -170,7 +170,7 @@ class ModuleManager:
             missing = self._check_required_packages(module_config)
             if missing:
                 logger.error(
-                    f"Module {module_name} missing required packages: {', '.join(missing)}"
+                    f"Module {module_name} Missing required packages: {', '.join(missing)}"
                 )
                 default_flag_manager.flag(
                     module_name, f"Missing packages: {', '.join(missing)}"
@@ -180,9 +180,6 @@ class ModuleManager:
 
             if not await self._load_dependencies(module_name, module_config):
                 self.module_states[module_name] = ModuleState.ERROR
-                return False
-
-            if not await self._check_required_packages(module_name, module_config):
                 return False
 
             with time_operation(f"Module {module_name} load"):
@@ -294,17 +291,6 @@ class ModuleManager:
                 if not await self.load_module(dep):
                     logger.error(f"Dependency {dep} for {module_name} failed to load")
                     return False
-        return True
-
-    async def _check_required_packages(self, module_name: str, config: ModuleConfig) -> bool:
-        missing = [p for p in config.required_packages if importlib.util.find_spec(p) is None]
-        if missing:
-            logger.error(
-                f"Missing required packages for {module_name}: {', '.join(missing)}"
-            )
-            default_flag_manager.flag(module_name, "missing_required_packages")
-            self.module_states[module_name] = ModuleState.SAFE_MODE
-            return False
         return True
 
     async def _initialize_module(

--- a/jarvis/core/sensor_manager.py
+++ b/jarvis/core/sensor_manager.py
@@ -57,7 +57,11 @@ class SensorManager:
             try:
                 text = await voice.listen()
                 if text:
-                    await self.event_queue.emit("voice_command", text)
+                    if hasattr(self.event_queue, "register_channel"):
+                        token = self.jarvis.settings.voice_command_token
+                        await self.event_queue.emit("voice_command", token, text)
+                    else:
+                        await self.event_queue.emit("voice_command", text)
             except asyncio.CancelledError:
                 break
             await asyncio.sleep(0.1)
@@ -69,7 +73,15 @@ class SensorManager:
                 now = time.monotonic()
                 for task in list(self.scheduled_tasks):
                     if now >= task.next_run:
-                        await self.event_queue.emit("scheduled_tick", task=task)
+                        if hasattr(self.event_queue, "register_channel"):
+                            token = self.jarvis.settings.scheduled_tick_token
+                            await self.event_queue.emit(
+                                "scheduled_tick", token, task=task
+                            )
+                        else:
+                            await self.event_queue.emit(
+                                "scheduled_tick", task=task
+                            )
                         task.next_run = now + task.interval
                 await asyncio.sleep(1)
             except asyncio.CancelledError:

--- a/tests/test_secure_event_queue.py
+++ b/tests/test_secure_event_queue.py
@@ -1,0 +1,26 @@
+import asyncio
+import pytest
+
+from jarvis.secure_event_queue import SecureEventQueue
+
+@pytest.mark.asyncio
+async def test_secure_event_queue_happy_path():
+    q = SecureEventQueue()
+    q.register_channel("c", "t")
+    received = []
+    q.subscribe("c", "t", lambda v: received.append(v))
+    await q.start()
+    await q.emit("c", "t", 1)
+    await asyncio.sleep(0.05)
+    await q.stop()
+    assert received == [1]
+
+
+@pytest.mark.asyncio
+async def test_secure_event_queue_invalid_token():
+    q = SecureEventQueue()
+    q.register_channel("c", "t")
+    await q.start()
+    with pytest.raises(ValueError):
+        await q.emit("c", "bad", 1)
+    await q.stop()


### PR DESCRIPTION
## Summary
- implement `SecureEventQueue` with per-channel tokens
- add unique queue ordering to `EventQueue`
- wire up optional secure queue usage in app and core
- register secure channels and settings
- update logging text for safe mode module check
- add new tests for `SecureEventQueue`

## Testing
- `pytest tests/test_module_safe_mode.py::test_module_load_safe_mode -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dfaf80c9c832d8c2b83777b7b2e3a