### PR TITLE
Document module required_packages safe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,13 +332,14 @@ required packages are installed. When creating a package directory, include an
 
 Modules receive a small configuration dictionary when loaded. In addition to
 fields like `enabled` and `dependencies` you can now specify a
-`requirements` list. Each item is a pip-style package specifier that must be
-importable before the module starts.
+`required_packages` list. Each item is a pip-style package name that must be
+importable before the module starts. Missing packages place the module in
+**safe mode** and skip initialisation.
 
 ```yaml
 modules:
   postgres_interface:
-    requirements:
+    required_packages:
       - asyncpg>=0.29
 ```
 

--- a/docs/kali_tools.md
+++ b/docs/kali_tools.md
@@ -38,6 +38,30 @@ mode when they are unavailable.
   await run_mitmproxy("-p 8080")
   ```
 
+## Handling missing dependencies
+
+Declare optional tools in `required_packages` under the module's configuration:
+
+```yaml
+modules:
+  kali_tools:
+    required_packages:
+      - yara
+```
+
+When `yara` is missing the startup log shows:
+
+```
+ERROR - Module kali_tools missing required packages: yara
+WARNING - kali_tools entered SAFE_MODE. Commands disabled.
+```
+
+Install the package and reload the module to exit safe mode:
+
+```
+reload --module=kali_tools
+```
+
 ## Updating allowed networks
 
 Allowed target networks are read from `config/config.yaml` when the module is

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -13,13 +13,14 @@ are resumed.
 ## Module configuration
 
 The `ModuleManager` reads configuration from `config/config.yaml`. Each module
-section accepts a `requirements` list containing pip-style package specifiers.
-They must be importable before the module starts.
+section accepts a `required_packages` list containing pip-style package names.
+They must be importable before the module starts. Missing packages put the
+module into **safe mode** and skip setup.
 
 ```yaml
 modules:
   git_manager:
-    requirements:
+    required_packages:
       - gitpython>=3.1
 ```
 


### PR DESCRIPTION
## Summary
- document `required_packages` field in README
- update modules doc for `required_packages`
- add dependency missing example to Kali tools docs

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e748a85e8832dae8e5a4cda4c4536