### PR TITLE
Fix CI workflow yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
+---
 name: Jarvis Full Auto CI
 
-on:
+'on':
   push:
     branches: [main]
     paths:
@@ -11,7 +12,7 @@ on:
     paths:
       - '**.py'
       - '.github/workflows/ci.yml'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- fix lint warnings in CI workflow by quoting the `on` key and adding `---` document start
- allow manual execution with `workflow_dispatch: {}`

## Testing
- `pytest --maxfail=3 --disable-warnings` *(fails: ForwardRef._evaluate() missing required parameter)*

------
https://chatgpt.com/codex/tasks/task_e_685f00f8eab0832da4e7becc0088b7e8